### PR TITLE
missing index.html in unstable

### DIFF
--- a/docs/unstable/index.html
+++ b/docs/unstable/index.html
@@ -1,0 +1,3 @@
+---
+layout: repo
+---


### PR DESCRIPTION
This command to generate the repo url fails
```
sudo sh -c "curl -s https://nonfree.eu/$(pacman-mirrors -G)/ > /etc/pacman.d/mesa-nonfree.pre.repo.conf"
```

I am  unsure about this but I believe the missing index.html is causing it.

I think the url is generated by adding the repo template layout but I am unsure if the extension is required in layout header.